### PR TITLE
Fix build and add custom get scope range function

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "consolidate": "^0.16.0",
     "esm": "^3.2.25",
     "fast-glob": "^3.2.7",
-    "fluent-vue-cli": "^3.0.0-beta.19",
+    "fluent-vue-cli": "3.0.4",
     "glob-gitignore": "^1.0.14",
     "htmlparser2": "^6.1.0",
     "iconv-lite": "^0.6.3",

--- a/src/frameworks/custom.ts
+++ b/src/frameworks/custom.ts
@@ -1,8 +1,8 @@
 import path from 'path'
 import fs from 'fs'
-import { workspace, FileSystemWatcher } from 'vscode'
+import { workspace, FileSystemWatcher, TextDocument } from 'vscode'
 import YAML from 'js-yaml'
-import { Framework } from './base'
+import { Framework, ScopeRange } from './base'
 import { Global } from '~/core'
 import { LanguageId, File, Log } from '~/utils'
 
@@ -11,6 +11,7 @@ const CustomFrameworkConfigFilename = './.vscode/i18n-ally-custom-framework.yml'
 interface CustomFrameworkConfig {
   languageIds?: LanguageId[] | LanguageId
   usageMatchRegex?: string[] | string
+  namespaceMatchRegex?: string
   refactorTemplates?: string[]
   monopoly?: boolean
 
@@ -79,6 +80,38 @@ class CustomFramework extends Framework {
   refactorTemplates(keypath: string) {
     return (this.data?.refactorTemplates || ['$1'])
       .map(i => i.replace(/\$1/g, keypath))
+  }
+
+  getScopeRange(document: TextDocument): ScopeRange[] | undefined {
+    if (!this.data?.namespaceMatchRegex)
+      return undefined
+
+    if (!this.languageIds.includes(document.languageId as any))
+      return
+
+    const ranges: ScopeRange[] = []
+    const text = document.getText()
+    const reg = new RegExp(this.data.namespaceMatchRegex, 'g')
+
+    for (const match of text.matchAll(reg)) {
+      if (match?.index == null)
+        continue
+
+      // end previous scope
+      if (ranges.length)
+        ranges[ranges.length - 1].end = match.index
+
+      // start new scope if namespace provides
+      if (match[1]) {
+        ranges.push({
+          start: match.index,
+          end: text.length,
+          namespace: match[1] as string,
+        })
+      }
+    }
+
+    return ranges
   }
 
   startWatch(root?: string) {

--- a/src/frameworks/i18next.ts
+++ b/src/frameworks/i18next.ts
@@ -55,7 +55,7 @@ class I18nextFramework extends Framework {
     '{key}_two',
     '{key}_few',
     '{key}_many',
-    '{key}_other'
+    '{key}_other',
   ]
 
   refactorTemplates(keypath: string) {

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -3,7 +3,8 @@ import { PackageJSONParser, PubspecYAMLParser, ComposerJSONParser, GemfileParser
 import { Framework, PackageFileType } from './base'
 import VueFramework from './vue'
 import FluentVueFramework from './fluent-vue'
-import ReactFramework from './react'
+import ReactI18nextFramework from './react-i18next'
+import ReactIntlFramework from './react-intl'
 import I18nextFramework from './i18next'
 import VSCodeFramework from './vscode'
 import NgxTranslateFramework from './ngx-translate'
@@ -39,7 +40,8 @@ export const frameworks: Framework[] = [
   new CustomFramework(),
 
   new VueFramework(),
-  new ReactFramework(),
+  new ReactI18nextFramework(),
+  new ReactIntlFramework(),
   new NgxTranslateFramework(),
   new VSCodeFramework(),
   new FlutterFramework(),

--- a/src/frameworks/react-i18next.ts
+++ b/src/frameworks/react-i18next.ts
@@ -1,4 +1,4 @@
-import { I18nextFramework } from './i18next'
+import { Framework } from './base'
 import { LanguageId } from '~/utils'
 
 class ReactI18nextFramework extends Framework {

--- a/src/frameworks/react-intl.ts
+++ b/src/frameworks/react-intl.ts
@@ -7,7 +7,7 @@ class ReactFramework extends Framework {
 
   detection= {
     packageJSON: [
-      'react-intl'
+      'react-intl',
     ],
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -994,10 +994,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fluent/syntax@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@fluent/syntax/-/syntax-0.17.0.tgz#3e6385c44bda2a44a68b83a1efbadc1a134e9805"
-  integrity sha512-fgJNUZRBk/n5MO5AxZ7Vvv8aCzMF6NanGBS1GFR2HG2lnsGqHLAe9OeHpyg+FkKfP5SvOtbyk3Nkza5iIwN/Ug==
+"@fluent/syntax@^0.18.0":
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/@fluent/syntax/-/syntax-0.18.1.tgz#745f4028f4ad4463200b953c6a3d6d54839d33c8"
+  integrity sha512-h0dnIoIg1RwUZRKynTizlVCe0v5qAO9d92ugmRi8sVMM15mwwftf7dpEKdDRc/pybbrpDhmvZRykEel0Cs/RYg==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
@@ -2380,6 +2380,11 @@ bulk-replace@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/bulk-replace/-/bulk-replace-0.0.1.tgz#f095682a896abd4b3d9e08de409cc222e213f9dd"
   integrity sha1-8JVoKolqvUs9ngjeQJzCIuIT+d0=
+
+cac@^6.7.12:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
 
 cacache@^12.0.2:
   version "12.0.4"
@@ -4760,6 +4765,17 @@ fast-glob@^3.1.1, fast-glob@^3.2.7:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.2.11:
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -4920,14 +4936,17 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
   integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
 
-fluent-vue-cli@^3.0.0-beta.19:
-  version "3.0.0-beta.19"
-  resolved "https://registry.yarnpkg.com/fluent-vue-cli/-/fluent-vue-cli-3.0.0-beta.19.tgz#262a7ffd6b87f05278f8291b50155a0907d9b294"
-  integrity sha512-w6Ry+nRzp1oX3v9KwE0w+f+bWI5aIL9ViPYGEUx5y1o7TmbtJQEpi1kQO7jz4Ixhk9kviKTk8wInTksIxHtmFw==
+fluent-vue-cli@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/fluent-vue-cli/-/fluent-vue-cli-3.0.4.tgz#7d7d87b7ccf2cb6746436e986c97142b60878baa"
+  integrity sha512-8jyxLpXd+fPXQKfEDYnFCJM7kg+U/YwV2xFm8EjM78AVJPUzlwtgJXz6XwuaDJUNBbFp64NtLJWdmba0NfqyJw==
   dependencies:
-    "@fluent/syntax" "^0.17.0"
+    "@fluent/syntax" "^0.18.0"
     "@vue/compiler-dom" "^3.2.6"
     "@vue/compiler-sfc" "^3.2.6"
+    cac "^6.7.12"
+    fast-glob "^3.2.11"
+    unixify "^1.0.0"
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -10896,6 +10915,13 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unixify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unixify/-/unixify-1.0.0.tgz#3a641c8c2ffbce4da683a5c70f03a462940c2090"
+  integrity sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==
+  dependencies:
+    normalize-path "^2.1.1"
 
 unplugin@^0.0.5:
   version "0.0.5"


### PR DESCRIPTION
Fixes:

- Updating `fluent-vue-cli` version
- Fixing build break caused by this PR: https://github.com/lokalise/i18n-ally/pull/735

Enhancements:

- Implemented `getScopeRange` for the `custom` framework.
Example usage: ```namespaceMatchRegex: "localizationUtils\\(\\s*\\[?\\s*['\"`](.*?)['\"`]"```